### PR TITLE
[oneDNN] Resolve the issue of 'ONEDNN_DEFAULT_FPMATH_MODE' environment variable not working.

### DIFF
--- a/tensorflow/core/kernels/mkl_matmul_op.cc
+++ b/tensorflow/core/kernels/mkl_matmul_op.cc
@@ -43,6 +43,13 @@ class MklMatMulOp : public OpKernel {
   explicit MklMatMulOp(OpKernelConstruction* ctx) : OpKernel(ctx) {
     OP_REQUIRES_OK(ctx, ctx->GetAttr("transpose_a", &transpose_a_));
     OP_REQUIRES_OK(ctx, ctx->GetAttr("transpose_b", &transpose_b_));
+    string _onednn_fpmath_mode = "";
+    string _dnnl_fpmath_mode = "";
+    OP_REQUIRES_OK(ctx, ReadStringFromEnvVar("ONEDNN_DEFAULT_FPMATH_MODE",
+                                                "", &_onednn_fpmath_mode));
+    OP_REQUIRES_OK(ctx, ReadStringFromEnvVar("DNNL_DEFAULT_FPMATH_MODE",
+                                                "", &_dnnl_fpmath_mode));
+    FPMATH_MODE = _onednn_fpmath_mode != "" | _dnnl_fpmath_mode != "";
   }
 
   void Compute(OpKernelContext* ctx) override {
@@ -102,6 +109,7 @@ class MklMatMulOp : public OpKernel {
  private:
   bool transpose_a_;
   bool transpose_b_;
+  bool FPMATH_MODE;
   // --------------------------------------------------------------------------
   //
   // @brief Matrix-Matrix Multiplication with FP32 tensors, a, b, c using CBLAS
@@ -160,6 +168,11 @@ class MklMatMulOp : public OpKernel {
     // the kernel single threaded. Here we are coming up with a cost model based
     // on L1 sizes. If we find that matrices are small enough, we will execute
     // single threaded. This may need tuning.
+    if (FPMATH_MODE){
+      dnnl_gemm<float>(char_transa, char_transb, m, n, k,
+                        alpha, a, lda, b, ldb, beta, c, ldc, ctx);
+      return;
+    }
     if (ExecuteSingleThreadedGemm(m, n, k)) {
       // For now, call single-threaded gemm.
       MklDnnThreadPool eigen_tp(ctx, 1);


### PR DESCRIPTION
Resolve the issue of '**ONEDNN_DEFAULT_FPMATH_MODE**' environment variable not working in oneDNN.
The feature introduction can be found at the link below:
https://oneapi-src.github.io/oneDNN/dev_guide_attributes_fpmath_mode.html#the-floating-point-math-mode-attribute