### PR TITLE
[Embedding] Refactor the structure of MultiTierStorage class and its subclasses.

### DIFF
--- a/tensorflow/core/framework/embedding/dram_leveldb_storage.h
+++ b/tensorflow/core/framework/embedding/dram_leveldb_storage.h
@@ -16,7 +16,9 @@ limitations under the License.
 #define TENSORFLOW_CORE_FRAMEWORK_EMBEDDING_DRAM_LEVELDB_STORAGE_H_
 
 #include "tensorflow/core/framework/embedding/leveldb_kv.h"
+#include "tensorflow/core/framework/embedding/cpu_hash_map_kv.h"
 #include "tensorflow/core/framework/embedding/multi_tier_storage.h"
+#include "tensorflow/core/framework/embedding/single_tier_storage.h"
 
 namespace tensorflow {
 template <class V>
@@ -31,55 +33,23 @@ class DramLevelDBStore : public MultiTierStorage<K, V> {
  public:
   DramLevelDBStore(const StorageConfig& sc, Allocator* alloc,
       LayoutCreator<V>* lc, const std::string& name)
-      : alloc_(alloc), layout_creator_(lc),
-        MultiTierStorage<K, V>(sc, name) {
-    dram_kv_ = new LocklessHashMap<K, V>();
-    leveldb_ = new LevelDBKV<K, V>(sc.path);
-    if (sc.embedding_config.steps_to_live != 0) {
-      dram_policy_ = new GlobalStepShrinkPolicy<K, V>(dram_kv_, alloc_,
-          sc.embedding_config.slot_num + 1);
-      leveldb_policy_ = new GlobalStepShrinkPolicy<K, V>(leveldb_, alloc_,
-          sc.embedding_config.slot_num + 1);
-    } else if (sc.embedding_config.l2_weight_threshold != -1.0) {
-      dram_policy_ =
-          new L2WeightShrinkPolicy<K, V>(
-              sc.embedding_config.l2_weight_threshold,
-              sc.embedding_config.primary_emb_index,
-              Storage<K, V>::GetOffset(sc.embedding_config.primary_emb_index),
-              dram_kv_, alloc_,
-              sc.embedding_config.slot_num + 1);
-      leveldb_policy_ =
-          new L2WeightShrinkPolicy<K, V>(
-              sc.embedding_config.l2_weight_threshold,
-              sc.embedding_config.primary_emb_index,
-              Storage<K, V>::GetOffset(sc.embedding_config.primary_emb_index),
-              leveldb_, alloc_,
-              sc.embedding_config.slot_num + 1);
-    } else {
-      dram_policy_ = nullptr;
-      leveldb_policy_ = nullptr;
-    }
-
-    MultiTierStorage<K, V>::kvs_.emplace_back(
-        KVInterfaceDescriptor<K, V>(dram_kv_, alloc_, dram_mu_, dram_policy_));
-    MultiTierStorage<K, V>::kvs_.emplace_back(
-        KVInterfaceDescriptor<K, V>(leveldb_, alloc_,
-                                    leveldb_mu_, leveldb_policy_));
+      : MultiTierStorage<K, V>(sc, name) {
+    dram_ = new DramStorage<K, V>(sc, alloc, lc, new LocklessHashMap<K, V>());
+    leveldb_ = new LevelDBStore<K, V>(sc, alloc, lc);
   }
 
   ~DramLevelDBStore() override {
-    MultiTierStorage<K, V>::ReleaseValues(
-        {std::make_pair(dram_kv_, alloc_)});
-    if (dram_policy_ != nullptr) delete dram_policy_;
-    if (leveldb_policy_ != nullptr) delete leveldb_policy_;
+    MultiTierStorage<K, V>::DeleteFromEvictionManager();
+    delete dram_;
+    delete leveldb_;
   }
 
   TF_DISALLOW_COPY_AND_ASSIGN(DramLevelDBStore);
 
   Status Get(K key, ValuePtr<V>** value_ptr) override {
-    Status s = dram_kv_->Lookup(key, value_ptr);
+    Status s = dram_->Get(key, value_ptr);
     if (!s.ok()) {
-      s = leveldb_->Lookup(key, value_ptr);
+      s = leveldb_->Get(key, value_ptr);
     }
     return s;
   }
@@ -89,48 +59,38 @@ class DramLevelDBStore : public MultiTierStorage<K, V> {
   }
 
   void Insert(K key, ValuePtr<V>** value_ptr,
-              int64 alloc_len) override {
-    do {
-      *value_ptr = layout_creator_->Create(alloc_, alloc_len);
-      Status s = dram_kv_->Insert(key, *value_ptr);
-      if (s.ok()) {
-        break;
-      } else {
-        (*value_ptr)->Destroy(alloc_);
-        delete *value_ptr;
-      }
-    } while (!(dram_kv_->Lookup(key, value_ptr)).ok());
+              size_t alloc_len) override {
+    dram_->Insert(key, value_ptr, alloc_len);
   }
 
   Status GetOrCreate(K key, ValuePtr<V>** value_ptr,
       size_t size, CopyBackFlag &need_copyback) override {
-    need_copyback = NOT_COPYBACK;
-    return GetOrCreate(key, value_ptr, size);
+    LOG(FATAL)<<"GetOrCreate(K key, ValuePtr<V>** value_ptr, "
+              <<"size_t size, CopyBackFlag &need_copyback) "
+              <<"in DramLevelDBStore can not be called.";
   }
 
   Status GetOrCreate(K key, ValuePtr<V>** value_ptr,
       size_t size) override {
-    Status s = dram_kv_->Lookup(key, value_ptr);
+    Status s = dram_->Get(key, value_ptr);
     if (s.ok()) {
       return s;
     }
-    s = leveldb_->Lookup(key, value_ptr);
-    if (!s.ok()) {
-      *value_ptr = layout_creator_->Create(alloc_, size);
-    }
-
-    s = dram_kv_->Insert(key, *value_ptr);
+    s = leveldb_->Get(key, value_ptr);
     if (s.ok()) {
-      return s;
+      s = dram_->TryInsert(key, *value_ptr);
+      if (s.ok()) {
+        return s;
+      }
+      leveldb_->DestroyValuePtr(*value_ptr);
+      return dram_->Get(key, value_ptr);
     }
-    // Insert Failed, key already exist
-    (*value_ptr)->Destroy(alloc_);
-    delete *value_ptr;
-    return dram_kv_->Lookup(key, value_ptr);
+    dram_->Insert(key, value_ptr, size);
+    return Status::OK();
   }
  
   Status Remove(K key) override {
-    dram_kv_->Remove(key);
+    dram_->Remove(key);
     leveldb_->Remove(key);
     return Status::OK();
   }
@@ -150,28 +110,110 @@ class DramLevelDBStore : public MultiTierStorage<K, V> {
   }
 
   void iterator_mutex_lock() override {
-    leveldb_mu_.lock();
+    leveldb_->get_mutex()->lock();
   }
 
   void iterator_mutex_unlock() override {
-    leveldb_mu_.unlock();
+    leveldb_->get_mutex()->unlock();
   }
 
   int64 Size() const override {
-    int64 total_size = dram_kv_->Size();
+    int64 total_size = dram_->Size();
     total_size += leveldb_->Size();
     return total_size;
+  }
+
+  int64 Size(int level) const override {
+    if (level == 0) {
+      return dram_->Size();
+    } else if (level == 1) {
+      return leveldb_->Size();
+    } else {
+      return -1;
+    }
+  }
+
+  int LookupTier(K key) const override {
+    Status s = dram_->Contains(key);
+    if (s.ok())
+      return 0;
+    s = leveldb_->Contains(key);
+    if (s.ok())
+      return 1;
+    return -1;
   }
 
   Status GetSnapshot(std::vector<K>* key_list,
       std::vector<ValuePtr<V>*>* value_ptr_list) override {
     {
-      mutex_lock l(dram_mu_);
-      TF_CHECK_OK(dram_kv_->GetSnapshot(key_list, value_ptr_list));
+      mutex_lock l(*(dram_->get_mutex()));
+      TF_CHECK_OK(dram_->GetSnapshot(key_list, value_ptr_list));
     }
     {
-      mutex_lock l(leveldb_mu_);
+      mutex_lock l(*(leveldb_->get_mutex()));
       TF_CHECK_OK(leveldb_->GetSnapshot(key_list, value_ptr_list));
+    }
+    return Status::OK();
+  }
+
+  Status Shrink(int64 value_len) override {
+    dram_->Shrink(value_len);
+    leveldb_->Shrink(value_len);
+    return Status::OK();
+  }
+
+  Status Shrink(int64 global_step, int64 steps_to_live) override {
+    dram_->Shrink(global_step, steps_to_live);
+    leveldb_->Shrink(global_step, steps_to_live);
+    return Status::OK();
+  }
+
+  int64 GetSnapshot(std::vector<K>* key_list,
+      std::vector<V* >* value_list,
+      std::vector<int64>* version_list,
+      std::vector<int64>* freq_list,
+      const EmbeddingConfig& emb_config,
+      FilterPolicy<K, V, EmbeddingVar<K, V>>* filter,
+      embedding::Iterator** it) override {
+    {
+      mutex_lock l(*(dram_->get_mutex()));
+      std::vector<ValuePtr<V>*> value_ptr_list;
+      std::vector<K> key_list_tmp;
+      TF_CHECK_OK(dram_->GetSnapshot(&key_list_tmp, &value_ptr_list));
+      MultiTierStorage<K, V>::SetListsForCheckpoint(
+          key_list_tmp, value_ptr_list, emb_config,
+          key_list, value_list, version_list, freq_list);
+    }
+    {
+      mutex_lock l(*(leveldb_->get_mutex()));
+      *it = leveldb_->GetIterator();
+    }
+    return key_list->size();
+  }
+
+  Status Eviction(K* evict_ids, int64 evict_size) override {
+    ValuePtr<V>* value_ptr;
+    for (int64 i = 0; i < evict_size; ++i) {
+      if (dram_->Get(evict_ids[i], &value_ptr).ok()) {
+        TF_CHECK_OK(leveldb_->Commit(evict_ids[i], value_ptr));
+        TF_CHECK_OK(dram_->Remove(evict_ids[i]));
+        dram_->DestroyValuePtr(value_ptr);
+      }
+    }
+    return Status::OK();
+  }
+
+  Status EvictionWithDelayedDestroy(K* evict_ids, int64 evict_size) override {
+    mutex_lock l(*(dram_->get_mutex()));
+    mutex_lock l1(*(leveldb_->get_mutex()));
+    MultiTierStorage<K, V>::ReleaseInvalidValuePtr(dram_->alloc_);
+    ValuePtr<V>* value_ptr = nullptr;
+    for (int64 i = 0; i < evict_size; ++i) {
+      if (dram_->Get(evict_ids[i], &value_ptr).ok()) {
+        TF_CHECK_OK(leveldb_->Commit(evict_ids[i], value_ptr));
+        TF_CHECK_OK(dram_->Remove(evict_ids[i]));
+        MultiTierStorage<K, V>::KeepInvalidValuePtr(value_ptr);
+      }
     }
     return Status::OK();
   }
@@ -182,14 +224,8 @@ class DramLevelDBStore : public MultiTierStorage<K, V> {
   }
 
  private:
-  KVInterface<K, V>* dram_kv_;
-  KVInterface<K, V>* leveldb_;
-  Allocator* alloc_;
-  ShrinkPolicy<K, V>* dram_policy_;
-  ShrinkPolicy<K, V>* leveldb_policy_;
-  LayoutCreator<V>* layout_creator_;
-  mutex dram_mu_; //must be locked before leveldb_mu_ is locked
-  mutex leveldb_mu_;
+  DramStorage<K, V>* dram_;
+  LevelDBStore<K, V>* leveldb_;
 };
 } // embedding
 } // tensorflow

--- a/tensorflow/core/framework/embedding/dram_pmem_storage.h
+++ b/tensorflow/core/framework/embedding/dram_pmem_storage.h
@@ -16,6 +16,8 @@ limitations under the License.
 #define TENSORFLOW_CORE_FRAMEWORK_EMBEDDING_DRAM_PMEM_STORAGE_H_
 
 #include "tensorflow/core/framework/embedding/multi_tier_storage.h"
+#include "tensorflow/core/framework/embedding/single_tier_storage.h"
+#include "tensorflow/core/framework/embedding/cpu_hash_map_kv.h"
 
 namespace tensorflow {
 template <class V>
@@ -32,55 +34,23 @@ class DramPmemStorage : public MultiTierStorage<K, V> {
   DramPmemStorage(const StorageConfig& sc, Allocator* dram_alloc,
       Allocator* pmem_alloc, LayoutCreator<V>* lc,
       const std::string& name)
-      : dram_alloc_(dram_alloc), pmem_alloc_(pmem_alloc),
-        layout_creator_(lc), MultiTierStorage<K, V>(sc, name) {
-    dram_kv_ = new LocklessHashMap<K, V>();
-    pmem_kv_ = new LocklessHashMap<K, V>();
-    if (sc.embedding_config.steps_to_live != 0) {
-      dram_policy_ = new GlobalStepShrinkPolicy<K, V>(dram_kv_, dram_alloc_,
-          sc.embedding_config.slot_num + 1);
-      pmem_policy_ = new GlobalStepShrinkPolicy<K, V>(pmem_kv_, pmem_alloc_,
-          sc.embedding_config.slot_num + 1);
-    } else if (sc.embedding_config.l2_weight_threshold != -1.0) {
-      dram_policy_ =
-          new L2WeightShrinkPolicy<K, V>(
-              sc.embedding_config.l2_weight_threshold,
-              sc.embedding_config.primary_emb_index,
-              Storage<K, V>::GetOffset(sc.embedding_config.primary_emb_index),
-              dram_kv_, dram_alloc_,
-              sc.embedding_config.slot_num + 1);
-      pmem_policy_ =
-          new L2WeightShrinkPolicy<K, V>(
-              sc.embedding_config.l2_weight_threshold,
-              sc.embedding_config.primary_emb_index,
-              Storage<K, V>::GetOffset(sc.embedding_config.primary_emb_index),
-              pmem_kv_, pmem_alloc_,
-              sc.embedding_config.slot_num + 1);
-    } else {
-      dram_policy_ = nullptr;
-      pmem_policy_ = nullptr;
-    }
-
-    MultiTierStorage<K, V>::kvs_.emplace_back(
-        KVInterfaceDescriptor<K, V>(dram_kv_, dram_alloc_, dram_mu_, dram_policy_));
-    MultiTierStorage<K, V>::kvs_.emplace_back(
-        KVInterfaceDescriptor<K, V>(pmem_kv_, pmem_alloc_, pmem_mu_, pmem_policy_));
+      : MultiTierStorage<K, V>(sc, name) {
+    dram_ = new DramStorage<K, V>(sc, dram_alloc, lc, new LocklessHashMap<K, V>());
+    pmem_ = new PmemLibpmemStorage<K, V>(sc, pmem_alloc, lc);
   }
 
   ~DramPmemStorage() override {
-    MultiTierStorage<K, V>::ReleaseValues(
-        {std::make_pair(dram_kv_, dram_alloc_),
-         std::make_pair(pmem_kv_, pmem_alloc_)});
-    if (dram_policy_ != nullptr) delete dram_policy_;
-    if (pmem_policy_ != nullptr) delete pmem_policy_;
+    MultiTierStorage<K, V>::DeleteFromEvictionManager();
+    delete dram_;
+    delete pmem_;
   }
 
   TF_DISALLOW_COPY_AND_ASSIGN(DramPmemStorage);
 
   Status Get(K key, ValuePtr<V>** value_ptr) override {
-    Status s = dram_kv_->Lookup(key, value_ptr);
+    Status s = dram_->Get(key, value_ptr);
     if (!s.ok()) {
-      s = pmem_kv_->Lookup(key, value_ptr);
+      s = pmem_->Get(key, value_ptr);
     }
     return s;
   }
@@ -90,23 +60,15 @@ class DramPmemStorage : public MultiTierStorage<K, V> {
   }
 
   void Insert(K key, ValuePtr<V>** value_ptr,
-              int64 alloc_len) override {
-    do {
-      *value_ptr = layout_creator_->Create(dram_alloc_, alloc_len);
-      Status s = dram_kv_->Insert(key, *value_ptr);
-      if (s.ok()) {
-        break;
-      } else {
-        (*value_ptr)->Destroy(dram_alloc_);
-        delete *value_ptr;
-      }
-    } while (!(dram_kv_->Lookup(key, value_ptr)).ok());
+              size_t alloc_len) override {
+    dram_->Insert(key, value_ptr, alloc_len);
   }
 
   Status GetOrCreate(K key, ValuePtr<V>** value_ptr,
       size_t size, CopyBackFlag &need_copyback) override {
-    need_copyback = NOT_COPYBACK;
-    return GetOrCreate(key, value_ptr, size);
+     LOG(FATAL)<<"GetOrCreate(K key, ValuePtr<V>** value_ptr, "
+              <<"size_t size, CopyBackFlag &need_copyback) "
+              <<"in DramPmemStorage can not be called.";
   }
 
   bool IsUseHbm() override {
@@ -125,51 +87,82 @@ class DramPmemStorage : public MultiTierStorage<K, V> {
 
   Status GetOrCreate(K key, ValuePtr<V>** value_ptr,
       size_t size) override {
-    Status s = dram_kv_->Lookup(key, value_ptr);
+    Status s = dram_->Get(key, value_ptr);
     if (s.ok()) {
       return s;
     }
-    s = pmem_kv_->Lookup(key, value_ptr);
+    s = pmem_->Get(key, value_ptr);
 
-    ValuePtr<V>* new_value_ptr = layout_creator_->Create(dram_alloc_, size);
+    ValuePtr<V>* new_value_ptr = dram_->CreateValuePtr(size);
     if (s.ok()) {
       memcpy(new_value_ptr->GetPtr(), (*value_ptr)->GetPtr(),
              sizeof(FixedLengthHeader) + sizeof(V) * size);
     }
     *value_ptr = new_value_ptr;
     
-    s = dram_kv_->Insert(key, *value_ptr);
+    s = dram_->TryInsert(key, *value_ptr);
     if (s.ok()) {
       return s;
     }
     // Insert Failed, key already exist
-    (*value_ptr)->Destroy(dram_alloc_);
-    delete *value_ptr;
-    return dram_kv_->Lookup(key, value_ptr);
+    dram_->DestroyValuePtr(*value_ptr);
+    return dram_->Get(key, value_ptr);
   }
 
   Status Remove(K key) override {
-    dram_kv_->Remove(key);
-    pmem_kv_->Remove(key);
+    dram_->Remove(key);
+    pmem_->Remove(key);
     return Status::OK();
   }
 
   int64 Size() const override {
-    int64 total_size = dram_kv_->Size();
-    total_size += pmem_kv_->Size();
+    int64 total_size = dram_->Size();
+    total_size += pmem_->Size();
     return total_size;
+  }
+
+  int64 Size(int level) const override {
+    if (level == 0) {
+      return dram_->Size();
+    } else if (level == 1) {
+      return pmem_->Size();
+    } else {
+      return -1;
+    }
+  }
+
+  int LookupTier(K key) const override {
+    Status s = dram_->Contains(key);
+    if (s.ok())
+      return 0;
+    s = pmem_->Contains(key);
+    if (s.ok())
+      return 1;
+    return -1;
   }
 
   Status GetSnapshot(std::vector<K>* key_list,
       std::vector<ValuePtr<V>* >* value_ptr_list) override {
     {
-      mutex_lock l(dram_mu_);
-      TF_CHECK_OK(dram_kv_->GetSnapshot(key_list, value_ptr_list));
+      mutex_lock l(*(dram_->get_mutex()));
+      TF_CHECK_OK(dram_->GetSnapshot(key_list, value_ptr_list));
     }
     {
-      mutex_lock l(pmem_mu_);
-      TF_CHECK_OK(pmem_kv_->GetSnapshot(key_list, value_ptr_list));
+      mutex_lock l(*(pmem_->get_mutex()));
+      TF_CHECK_OK(pmem_->GetSnapshot(key_list, value_ptr_list));
     }
+    return Status::OK();
+  }
+
+  Status Shrink(int64 value_len) override {
+    dram_->Shrink(value_len);
+    pmem_->Shrink(value_len);
+    return Status::OK();
+  }
+
+  Status Shrink(int64 global_step, int64 steps_to_live) override {
+    dram_->Shrink(global_step, steps_to_live);
+    pmem_->Shrink(global_step, steps_to_live);
     return Status::OK();
   }
 
@@ -181,19 +174,67 @@ class DramPmemStorage : public MultiTierStorage<K, V> {
     return;
   }
 
+  int64 GetSnapshot(std::vector<K>* key_list,
+      std::vector<V* >* value_list,
+      std::vector<int64>* version_list,
+      std::vector<int64>* freq_list,
+      const EmbeddingConfig& emb_config,
+      FilterPolicy<K, V, EmbeddingVar<K, V>>* filter,
+      embedding::Iterator** it) override {
+    {
+      mutex_lock l(*(dram_->get_mutex()));
+      std::vector<ValuePtr<V>*> value_ptr_list;
+      std::vector<K> key_list_tmp;
+      TF_CHECK_OK(dram_->GetSnapshot(&key_list_tmp, &value_ptr_list));
+      MultiTierStorage<K, V>::SetListsForCheckpoint(
+          key_list_tmp, value_ptr_list, emb_config,
+          key_list, value_list, version_list, freq_list);
+    }
+    {
+      mutex_lock l(*(pmem_->get_mutex()));
+      std::vector<ValuePtr<V>*> value_ptr_list;
+      std::vector<K> key_list_tmp;
+      TF_CHECK_OK(pmem_->GetSnapshot(&key_list_tmp, &value_ptr_list));
+      MultiTierStorage<K, V>::SetListsForCheckpoint(
+          key_list_tmp, value_ptr_list, emb_config,
+          key_list, value_list, version_list, freq_list);
+    }
+    return key_list->size();
+  }
+
+  Status Eviction(K* evict_ids, int64 evict_size) override {
+    ValuePtr<V>* value_ptr;
+    for (int64 i = 0; i < evict_size; ++i) {
+      if (dram_->Get(evict_ids[i], &value_ptr).ok()) {
+        TF_CHECK_OK(pmem_->Commit(evict_ids[i], value_ptr));
+        TF_CHECK_OK(dram_->Remove(evict_ids[i]));
+        dram_->DestroyValuePtr(value_ptr);
+      }
+    }
+    return Status::OK();
+  }
+
+  Status EvictionWithDelayedDestroy(K* evict_ids, int64 evict_size) override {
+    mutex_lock l(*(dram_->get_mutex()));
+    mutex_lock l1(*(pmem_->get_mutex()));
+    MultiTierStorage<K, V>::ReleaseInvalidValuePtr(dram_->alloc_);
+    ValuePtr<V>* value_ptr = nullptr;
+    for (int64 i = 0; i < evict_size; ++i) {
+      if (dram_->Get(evict_ids[i], &value_ptr).ok()) {
+        TF_CHECK_OK(pmem_->Commit(evict_ids[i], value_ptr));
+        TF_CHECK_OK(dram_->Remove(evict_ids[i]));
+        MultiTierStorage<K, V>::KeepInvalidValuePtr(value_ptr);
+      }
+    }
+    return Status::OK();
+  }
+
  protected:
   void SetTotalDims(int64 total_dims) override {}
 
  private:
-  KVInterface<K, V>* dram_kv_;
-  KVInterface<K, V>* pmem_kv_;
-  Allocator* dram_alloc_;
-  Allocator* pmem_alloc_;
-  ShrinkPolicy<K, V>* dram_policy_;
-  ShrinkPolicy<K, V>* pmem_policy_;
-  LayoutCreator<V>* layout_creator_;
-  mutex dram_mu_; // must be locked before pmem_mu_ is locked
-  mutex pmem_mu_;
+  DramStorage<K, V>* dram_;
+  PmemLibpmemStorage<K, V>* pmem_;
 };
 } // embedding
 } // tensorflow

--- a/tensorflow/core/framework/embedding/hbm_dram_storage.h
+++ b/tensorflow/core/framework/embedding/hbm_dram_storage.h
@@ -19,6 +19,7 @@ limitations under the License.
 #define EIGEN_USE_GPU
 #include "tensorflow/core/framework/embedding/lockless_hash_map_cpu.h"
 #include "tensorflow/core/framework/embedding/multi_tier_storage.h"
+#include "tensorflow/core/framework/embedding/single_tier_storage.h"
 #include "tensorflow/core/framework/embedding/hbm_storage_iterator.h"
 #include "tensorflow/core/platform/stream_executor.h"
 
@@ -37,151 +38,94 @@ class HbmDramStorage : public MultiTierStorage<K, V> {
  public:
   HbmDramStorage(const StorageConfig& sc, Allocator* gpu_alloc,
       Allocator* cpu_alloc, LayoutCreator<V>* lc, const std::string& name)
-      : cpu_alloc_(cpu_alloc), gpu_alloc_(gpu_alloc),
-        layout_creator_(lc), MultiTierStorage<K, V>(sc, name) {
-    hbm_kv_ = new LocklessHashMap<K, V>();
-    dram_kv_ = new LocklessHashMapCPU<K, V>(gpu_alloc);
-    if (sc.embedding_config.steps_to_live != 0) {
-      hbm_policy_ = new GlobalStepShrinkPolicy<K, V>(hbm_kv_, gpu_alloc_,
-         sc.embedding_config.slot_num + 1);
-      dram_policy_ = new GlobalStepShrinkPolicy<K, V>(dram_kv_, cpu_alloc_,
-         sc.embedding_config.slot_num + 1);
-    } else if (sc.embedding_config.l2_weight_threshold != -1.0) {
-      hbm_policy_ =
-          new L2WeightShrinkPolicy<K, V>(
-              sc.embedding_config.l2_weight_threshold,
-              sc.embedding_config.primary_emb_index,
-              Storage<K, V>::GetOffset(sc.embedding_config.primary_emb_index),
-              hbm_kv_, gpu_alloc_,
-              sc.embedding_config.slot_num + 1);
-      dram_policy_ =
-          new L2WeightShrinkPolicy<K, V>(
-              sc.embedding_config.l2_weight_threshold,
-              sc.embedding_config.primary_emb_index,
-              Storage<K, V>::GetOffset(sc.embedding_config.primary_emb_index),
-              dram_kv_, cpu_alloc_,
-              sc.embedding_config.slot_num + 1);
-    } else {
-      hbm_policy_ = nullptr;
-      dram_policy_ = nullptr;
-    }
-
-    MultiTierStorage<K, V>::kvs_.emplace_back(
-        KVInterfaceDescriptor<K, V>(hbm_kv_, gpu_alloc_, hbm_mu_, hbm_policy_));
-    MultiTierStorage<K, V>::kvs_.emplace_back(
-        KVInterfaceDescriptor<K, V>(dram_kv_, cpu_alloc, dram_mu_, dram_policy_));
-
+      : gpu_alloc_(gpu_alloc),
+        MultiTierStorage<K, V>(sc, name) {
+    hbm_ = new HbmStorageWithCpuKv<K, V>(sc, gpu_alloc, lc);
+    dram_ = new DramStorage<K, V>(sc, cpu_alloc, lc, new LocklessHashMapCPU<K, V>(gpu_alloc));
   }
 
   ~HbmDramStorage() override {
-    ReleaseValues({std::make_pair(hbm_kv_, gpu_alloc_),
-                   std::make_pair(dram_kv_, cpu_alloc_)});
-    if (hbm_policy_ != nullptr) delete hbm_policy_;
-    if (dram_policy_ != nullptr) delete dram_policy_;
+    MultiTierStorage<K, V>::DeleteFromEvictionManager();
+    delete hbm_;
+    delete dram_;
   }
 
   TF_DISALLOW_COPY_AND_ASSIGN(HbmDramStorage);
 
   Status Get(K key, ValuePtr<V>** value_ptr) override {
-    Status s = hbm_kv_->Lookup(key, value_ptr);
+    Status s = hbm_->Get(key, value_ptr);
     if (!s.ok()) {
-      s = dram_kv_->Lookup(key, value_ptr);
+      s = dram_->Get(key, value_ptr);
     }
     return s;
   }
 
   void Insert(K key, ValuePtr<V>* value_ptr) override {
-    do {
-      Status s = hbm_kv_->Insert(key, value_ptr);
-      if (s.ok()) {
-        break;
-      } else {
-        value_ptr->Destroy(gpu_alloc_);
-        delete value_ptr;
-      }
-    } while (!(hbm_kv_->Lookup(key, &value_ptr)).ok());
+    hbm_->Insert(key, value_ptr);
   }
 
   void Insert(K key, ValuePtr<V>** value_ptr,
-              int64 alloc_len) override {
-    do {
-      *value_ptr = layout_creator_->Create(gpu_alloc_, alloc_len);
-      Status s = hbm_kv_->Insert(key, *value_ptr);
-      if (s.ok()) {
-        break;
-      } else {
-        (*value_ptr)->Destroy(gpu_alloc_);
-        delete *value_ptr;
-      }
-    } while (!(hbm_kv_->Lookup(key, value_ptr)).ok());
+              size_t alloc_len) override {
+    hbm_->Insert(key, value_ptr, alloc_len);
   }
 
   void InsertToDram(K key, ValuePtr<V>** value_ptr,
               int64 alloc_len) override {
-    do {
-      *value_ptr = new NormalContiguousValuePtr<V>(ev_allocator(), alloc_len);
-      Status s = dram_kv_->Insert(key, *value_ptr);
-      if (s.ok()) {
-        break;
-      } else {
-        (*value_ptr)->Destroy(ev_allocator());
-        delete *value_ptr;
-      }
-    } while (!(dram_kv_->Lookup(key, value_ptr)).ok());
+    dram_->Insert(key, value_ptr, alloc_len);
   }
 
   Status GetOrCreate(K key, ValuePtr<V>** value_ptr,
       size_t size) override {
-    Status s = hbm_kv_->Lookup(key, value_ptr);
+    Status s = hbm_->Get(key, value_ptr);
     if (s.ok()) {
       return s;
     }
-    s = dram_kv_->Lookup(key, value_ptr);
+    ValuePtr<V>* gpu_value_ptr = hbm_->CreateValuePtr(size);
+    {
+      mutex_lock l(memory_pool_mu_);
+      gpu_value_ptr->SetPtr(embedding_mem_pool_->Allocate());
+    }
+    s = dram_->Get(key, value_ptr);
     if (s.ok()) {
       // copy dram value to hbm
-      auto gpu_value_ptr = layout_creator_->Create(gpu_alloc_, size);
-      gpu_value_ptr->SetPtr(embedding_mem_pool_->Allocate());
       V* cpu_data_address = (*value_ptr)->GetValue(0, 0);
       V* gpu_data_address = gpu_value_ptr->GetValue(0, 0);
       cudaMemcpy(gpu_data_address, cpu_data_address,
           size * sizeof(V), cudaMemcpyHostToDevice);
       *value_ptr = gpu_value_ptr;
-      return s;
+      memcpy(gpu_value_ptr->GetPtr(),
+             (*value_ptr)->GetPtr(),
+             sizeof(FixedLengthHeader));
     }
 
-    *value_ptr = layout_creator_->Create(gpu_alloc_, size);
-    s = hbm_kv_->Insert(key, *value_ptr);
+    s = hbm_->TryInsert(key, *value_ptr);
     if (s.ok()) {
-      (*value_ptr)->SetPtr(embedding_mem_pool_->Allocate());
       return s;
     }
     // Insert Failed, key already exist
+    {
+      mutex_lock l(memory_pool_mu_);
+      embedding_mem_pool_->Deallocate((*value_ptr)->GetValue(0, 0));
+    }
     delete *value_ptr;
-    return hbm_kv_->Lookup(key, value_ptr);
+    return hbm_->Get(key, value_ptr);
   }
 
   Status GetOrCreate(K key, ValuePtr<V>** value_ptr,
       size_t size, CopyBackFlag &need_copyback) override {
     need_copyback = NOT_COPYBACK;
-    Status s = hbm_kv_->Lookup(key, value_ptr);
+    Status s = hbm_->Get(key, value_ptr);
     if (s.ok()) {
       return s;
     }
-    s = dram_kv_->Lookup(key, value_ptr);
+    s = dram_->Get(key, value_ptr);
     if (s.ok()) {
       need_copyback = COPYBACK;
       return s;
     }
 
-    *value_ptr = layout_creator_->Create(gpu_alloc_, size);
-    s = hbm_kv_->Insert(key, *value_ptr);
-    if (s.ok()) {
-      return s;
-    }
-    // Insert Failed, key already exist
-    (*value_ptr)->Destroy(gpu_alloc_);
-    delete *value_ptr;
-    return hbm_kv_->Lookup(key, value_ptr);
+    hbm_->Insert(key, value_ptr, size);
+    return Status::OK();
   }
 
   void ImportToHbm(
@@ -202,8 +146,8 @@ class HbmDramStorage : public MultiTierStorage<K, V> {
       //Mutex with other Import Ops
       mutex_lock l(memory_pool_mu_);
       for (int64 i = 0; i < size; i++) {
-        dram_kv_->Lookup(ids[i], &cpu_value_ptrs[i]);
-        gpu_value_ptrs[i] = layout_creator_->Create(gpu_alloc_, value_len);
+        dram_->Get(ids[i], &cpu_value_ptrs[i]);
+        gpu_value_ptrs[i] = hbm_->CreateValuePtr(value_len);
         V* val_ptr = embedding_mem_pool_->Allocate();
         gpu_value_ptrs[i]->SetPtr(val_ptr);
         memcpy((char *)gpu_value_ptrs[i]->GetPtr(),
@@ -218,10 +162,10 @@ class HbmDramStorage : public MultiTierStorage<K, V> {
       memcpy(memcpy_buffer_cpu + i * value_len,
           cpu_value_ptrs[i]->GetValue(emb_index,
               Storage<K, V>::GetOffset(emb_index)), value_len * sizeof(V));
-      Status s = hbm_kv_->Insert(ids[i], gpu_value_ptrs[i]);
+      Status s = hbm_->TryInsert(ids[i], gpu_value_ptrs[i]);
       if (!s.ok()) {
         invalid_value_ptrs.emplace_back(gpu_value_ptrs[i]);
-        hbm_kv_->Lookup(ids[i], &gpu_value_ptrs[i]);
+        hbm_->Get(ids[i], &gpu_value_ptrs[i]);
       }
       gpu_value_ptrs[i]->SetInitialized(emb_index);
       value_address[i] = gpu_value_ptrs[i]->GetValue(
@@ -276,8 +220,7 @@ class HbmDramStorage : public MultiTierStorage<K, V> {
       for ( ; it != copyback_cursor.cend(); ++it, ++i) {
         int64 j = *it;
         memory_index[i] = j;
-        ValuePtr<V>* gpu_value_ptr =
-            layout_creator_->Create(gpu_alloc_, value_len);
+        ValuePtr<V>* gpu_value_ptr = hbm_->CreateValuePtr(value_len);
         V* val_ptr = embedding_mem_pool_->Allocate();
         bool flag = gpu_value_ptr->SetPtr(val_ptr);
         if (!flag) {
@@ -312,15 +255,35 @@ class HbmDramStorage : public MultiTierStorage<K, V> {
   }
 
   Status Remove(K key) override {
-    hbm_kv_->Remove(key);
-    dram_kv_->Remove(key);
+    hbm_->Remove(key);
+    dram_->Remove(key);
     return Status::OK();
   }
 
   int64 Size() const override {
-    int64 total_size = hbm_kv_->Size();
-    total_size += dram_kv_->Size();
+    int64 total_size = hbm_->Size();
+    total_size += dram_->Size();
     return total_size;
+  }
+
+  int64 Size(int level) const override {
+    if (level == 0) {
+      return hbm_->Size();
+    } else if (level == 1) {
+      return dram_->Size();
+    } else {
+      return -1;
+    }
+  }
+
+  int LookupTier(K key) const override {
+    Status s = hbm_->Contains(key);
+    if (s.ok())
+      return 0;
+    s = dram_->Contains(key);
+    if (s.ok())
+      return 1;
+    return -1;
   }
 
   bool IsUseHbm() override {
@@ -346,12 +309,12 @@ class HbmDramStorage : public MultiTierStorage<K, V> {
   Status GetSnapshot(std::vector<K>* key_list,
       std::vector<ValuePtr<V>* >* value_ptr_list) override {
     {
-      mutex_lock l(hbm_mu_);
-      TF_CHECK_OK(hbm_kv_->GetSnapshot(key_list, value_ptr_list));
+      mutex_lock l(*(hbm_->get_mutex()));
+      TF_CHECK_OK(hbm_->GetSnapshot(key_list, value_ptr_list));
     }
     {
-      mutex_lock l(dram_mu_);
-      TF_CHECK_OK(dram_kv_->GetSnapshot(key_list, value_ptr_list));
+      mutex_lock l(*(dram_->get_mutex()));
+      TF_CHECK_OK(dram_->GetSnapshot(key_list, value_ptr_list));
     }
     return Status::OK();
   }
@@ -367,15 +330,15 @@ class HbmDramStorage : public MultiTierStorage<K, V> {
     std::vector<K> temp_hbm_key_list, temp_dram_key_list;
     // Get Snapshot of HBM storage
     {
-      mutex_lock l(hbm_mu_);
-      TF_CHECK_OK(hbm_kv_->GetSnapshot(&temp_hbm_key_list,
-                                       &hbm_value_ptr_list));
+      mutex_lock l(*(hbm_->get_mutex()));
+      TF_CHECK_OK(hbm_->GetSnapshot(&temp_hbm_key_list,
+                                    &hbm_value_ptr_list));
     }
     // Get Snapshot of DRAM storage.
     {
-      mutex_lock l(dram_mu_);
-      TF_CHECK_OK(dram_kv_->GetSnapshot(&temp_dram_key_list,
-                                        &dram_value_ptr_list));
+      mutex_lock l(*(dram_->get_mutex()));
+      TF_CHECK_OK(dram_->GetSnapshot(&temp_dram_key_list,
+                                     &dram_value_ptr_list));
     }
     *it = new HbmDramIterator<K, V>(temp_hbm_key_list,
                                     temp_dram_key_list,
@@ -387,6 +350,18 @@ class HbmDramStorage : public MultiTierStorage<K, V> {
     // This return value is not the exact number of IDs
     // because the two tables intersect.
     return temp_hbm_key_list.size() + temp_dram_key_list.size();
+  }
+
+  Status Shrink(int64 value_len) override {
+    hbm_->Shrink(value_len);
+    dram_->Shrink(value_len);
+    return Status::OK();
+  }
+
+  Status Shrink(int64 global_step, int64 steps_to_live) override {
+    hbm_->Shrink(global_step, steps_to_live);
+    dram_->Shrink(global_step, steps_to_live);
+    return Status::OK();
   }
 
   void CreateEmbeddingMemoryPool(
@@ -424,32 +399,14 @@ class HbmDramStorage : public MultiTierStorage<K, V> {
     }
   }
 
-  void ReleaseValues(
-      const std::vector<
-          std::pair<KVInterface<K, V>*, Allocator*>>& kvs) {
-    for (int i = 0; i < kvs.size(); i++) {
-      std::vector<K> key_list;
-      std::vector<ValuePtr<V>*> value_ptr_list;
-      kvs[i].first->GetSnapshot(&key_list, &value_ptr_list);
-      if (i == 0) {
-        delete embedding_mem_pool_;
-      }
-      for (auto value_ptr : value_ptr_list) {
-        if (i != 0)
-          value_ptr->Destroy(kvs[i].second);
-        delete value_ptr;
-      } 
-    }
-  }
-
   void BatchEviction() override {
     constexpr int EvictionSize = 10000;
     K evic_ids[EvictionSize];
     if (!MultiTierStorage<K, V>::ready_eviction_) {
       return;
     }
-    mutex_lock l(hbm_mu_);
-    mutex_lock l1(dram_mu_);
+    mutex_lock l(*(hbm_->get_mutex()));
+    mutex_lock l1(*(dram_->get_mutex()));
 
     int64 cache_count = MultiTierStorage<K, V>::cache_->size();
     if (cache_count > MultiTierStorage<K, V>::cache_capacity_) {
@@ -463,39 +420,33 @@ class HbmDramStorage : public MultiTierStorage<K, V> {
       std::vector<ValuePtr<V>*> value_ptrs;
 
       for (int64 i = 0; i < true_size; ++i) {
-        if (hbm_kv_->Lookup(evic_ids[i], &value_ptr).ok()) {
+        if (hbm_->Get(evic_ids[i], &value_ptr).ok()) {
           keys.emplace_back(evic_ids[i]);
           value_ptrs.emplace_back(value_ptr);
         }
       }
-      dram_kv_->BatchCommit(keys, value_ptrs);
+      dram_->BatchCommit(keys, value_ptrs);
       {
         //Mutex with main thread
         mutex_lock l_mem(memory_pool_mu_);
         embedding_mem_pool_->Deallocate(value_ptrs);
       }
       for (auto it : keys) {
-        TF_CHECK_OK(hbm_kv_->Remove(it));
+        TF_CHECK_OK(hbm_->Remove(it));
       }
     }
   }
 
  protected:
   void SetTotalDims(int64 total_dims) override {
-    dram_kv_->SetTotalDims(total_dims);
+    dram_->SetTotalDims(total_dims);
   }
 
  private:
-  KVInterface<K, V>* hbm_kv_;
-  KVInterface<K, V>* dram_kv_;
-  EmbeddingMemoryPool<V>* embedding_mem_pool_;
+  HbmStorageWithCpuKv<K, V>* hbm_ = nullptr;
+  DramStorage<K, V>* dram_ = nullptr;
+  EmbeddingMemoryPool<V>* embedding_mem_pool_ = nullptr;
   Allocator* gpu_alloc_;
-  Allocator* cpu_alloc_;
-  ShrinkPolicy<K, V>* hbm_policy_;
-  ShrinkPolicy<K, V>* dram_policy_;
-  LayoutCreator<V>* layout_creator_;
-  mutex hbm_mu_; //must be locked before dram_mu_ is locked;
-  mutex dram_mu_;
   mutex memory_pool_mu_; //ensure thread safety of embedding_mem_pool_
 };
 } // embedding

--- a/tensorflow/core/framework/embedding/ssd_hash_kv.h
+++ b/tensorflow/core/framework/embedding/ssd_hash_kv.h
@@ -214,13 +214,13 @@ class SSDHashKV : public KVInterface<K, V> {
     path_ = io::JoinPath(
         path, "ssd_kv_" + std::to_string(Env::Default()->NowMicros()) + "_");
     hash_map_.max_load_factor(0.8);
-    hash_map_.set_empty_key_and_value(-1, nullptr);
+    hash_map_.set_empty_key_and_value(EMPTY_KEY, nullptr);
     hash_map_.set_counternum(16);
-    hash_map_.set_deleted_key(-2);
+    hash_map_.set_deleted_key(DELETED_KEY);
     evict_file_set_.max_load_factor(0.8);
-    evict_file_set_.set_empty_key_and_value(-1, -1);
+    evict_file_set_.set_empty_key_and_value(EMPTY_KEY, -1);
     evict_file_set_.set_counternum(16);
-    evict_file_set_.set_deleted_key(-2);
+    evict_file_set_.set_deleted_key(DELETED_KEY);
 
     new_value_ptr_fn_ = [this](size_t size) {
       return new NormalContiguousValuePtr<V>(alloc_, size);
@@ -339,6 +339,7 @@ class SSDHashKV : public KVInterface<K, V> {
       }
       delete it;
     }
+    DeallocateEmbPositions();
     delete[] write_buffer_;
     delete[] key_buffer_;
   }
@@ -818,6 +819,21 @@ class SSDHashKV : public KVInterface<K, V> {
                            ", evict_version: ", evict_version_,
                            ", compaction_version: ", compaction_version_);
   }
+ private:
+  void DeallocateEmbPositions() {
+    std::pair<const K, EmbPosition*> *hash_map_dump;
+    int64 bucket_count;
+    auto it = hash_map_.GetSnapshot();
+    hash_map_dump = it.first;
+    bucket_count = it.second;
+    for (int64 j = 0; j < bucket_count; j++) {
+      if (hash_map_dump[j].first != SSDHashKV<K, V>::EMPTY_KEY
+           && hash_map_dump[j].first != SSDHashKV<K, V>::DELETED_KEY) {
+        delete hash_map_dump[j].second;
+      }
+    }
+    free(hash_map_dump);
+  }
 
  private:
   size_t val_len_ = -1;
@@ -844,10 +860,11 @@ class SSDHashKV : public KVInterface<K, V> {
   mutex shutdown_mu_;
   mutex compact_save_mu_;
 
-  static constexpr int EMPTY_KEY = -1;
-  static constexpr int CAP_INVALID_POS = 200000;
-  static constexpr int CAP_INVALID_ID = 10000000;
-  static constexpr size_t BUFFER_SIZE = 1 << 27;
+  static const int EMPTY_KEY;
+  static const int DELETED_KEY;
+  static const int CAP_INVALID_POS;
+  static const int CAP_INVALID_ID;
+  static const size_t BUFFER_SIZE;
 
   std::vector<EmbFile*> emb_files_;
   std::deque<EmbPosition*> pos_out_of_date_;
@@ -866,6 +883,16 @@ class SSDHashKV : public KVInterface<K, V> {
   std::function<void(K, const ValuePtr<V>*, bool)> save_kv_fn_;
   EmbFileCreator* emb_file_creator_ = nullptr;
 };
+template <class K, class V>
+const int SSDHashKV<K, V>::EMPTY_KEY = -1;
+template <class K, class V>
+const int SSDHashKV<K, V>::DELETED_KEY = -2;
+template <class K, class V>
+const int SSDHashKV<K, V>::CAP_INVALID_POS = 200000;
+template <class K, class V>
+const int SSDHashKV<K, V>::CAP_INVALID_ID = 10000000;
+template <class K, class V>
+const size_t SSDHashKV<K, V>::BUFFER_SIZE = 1 << 27;
 
 }  // namespace embedding
 }  // namespace tensorflow

--- a/tensorflow/core/framework/embedding/storage.h
+++ b/tensorflow/core/framework/embedding/storage.h
@@ -72,7 +72,8 @@ class Storage {
   TF_DISALLOW_COPY_AND_ASSIGN(Storage);
 
   virtual Status Get(K key, ValuePtr<V>** value_ptr) = 0;
-  virtual void Insert(K key, ValuePtr<V>** value_ptr, int64 alloc_len) = 0;
+  virtual Status Contains(K key) = 0;
+  virtual void Insert(K key, ValuePtr<V>** value_ptr, size_t alloc_len) = 0;
   virtual void InsertToDram(K key, ValuePtr<V>** value_ptr,
                             int64 alloc_len) = 0;
   virtual void Insert(K key, ValuePtr<V>* value_ptr) = 0;
@@ -102,6 +103,7 @@ class Storage {
       std::vector<int64>* freq_list,
       const EmbeddingConfig& emb_config,
       SsdRecordDescriptor<K>* ssd_rec_desc) = 0;
+  virtual embedding::Iterator* GetIterator() = 0;
   virtual void RestoreSsdHashmap(
       K* key_list, int64* key_file_id_list,
       int64* key_offset_list, int64 num_of_keys,

--- a/tensorflow/core/framework/embedding/storage_factory.h
+++ b/tensorflow/core/framework/embedding/storage_factory.h
@@ -40,7 +40,7 @@ class StorageFactory {
     switch (sc.type) {
       case StorageType::DRAM:
         return new DramStorage<K, V>(sc, ev_allocator(),
-            layout_creator);
+            layout_creator, new LocklessHashMap<K, V>());
       case StorageType::PMEM_MEMKIND:
         return new PmemMemkindStorage<K, V>(sc, pmem_allocator(),
             layout_creator);
@@ -77,7 +77,7 @@ class StorageFactory {
 #endif  // GOOGLE_CUDA
       default:
         return new DramStorage<K, V>(sc, ev_allocator(),
-            layout_creator);
+            layout_creator, new LocklessHashMap<K, V>());
     }
   }
 };


### PR DESCRIPTION
1. The MultiTierStorage class no longer accesses the data of the KvInterface class
2. A subclass of MultiTierStorage consists of multiple SingleTierStorage objects, instead of KvInterface objects