### PR TITLE
[Dockerfile] Fix misuse of && in single pip install

### DIFF
--- a/cibuild/dockerfiles/Dockerfile.base-py3.6-cu114-ubuntu18.04
+++ b/cibuild/dockerfiles/Dockerfile.base-py3.6-cu114-ubuntu18.04
@@ -19,7 +19,7 @@ RUN apt-get update && \
 
 RUN pip install \
     astor==0.8.1 \
-    numpy==1.16.6 && \
+    numpy==1.16.6 \
     protobuf==3.17.3 && \
     pip install --no-deps \
     keras-preprocessing==1.0.5

--- a/cibuild/dockerfiles/Dockerfile.base-py3.6-cu116-ubuntu18.04
+++ b/cibuild/dockerfiles/Dockerfile.base-py3.6-cu116-ubuntu18.04
@@ -19,7 +19,7 @@ RUN apt-get update && \
 
 RUN pip install \
     astor==0.8.1 \
-    numpy==1.16.6 && \
+    numpy==1.16.6 \
     protobuf==3.17.3 && \
     pip install --no-deps \
     keras-preprocessing==1.0.5

--- a/cibuild/dockerfiles/Dockerfile.base-py3.8-cu117-ubuntu22.04
+++ b/cibuild/dockerfiles/Dockerfile.base-py3.8-cu117-ubuntu22.04
@@ -51,7 +51,7 @@ RUN pip install wheel==0.37.1
 
 RUN pip install \
     astor==0.8.1 \
-    numpy==1.16.6 && \
+    numpy==1.16.6 \
     protobuf==3.17.3 && \
     pip install --no-deps \
     keras-preprocessing==1.0.5

--- a/cibuild/dockerfiles/Dockerfile.base-py3.8-ubuntu20.04
+++ b/cibuild/dockerfiles/Dockerfile.base-py3.8-ubuntu20.04
@@ -19,7 +19,7 @@ RUN apt-get update && \
 
 RUN pip install \
     astor==0.8.1 \
-    numpy==1.16.6 && \
+    numpy==1.16.6 \
     protobuf==3.17.3 && \
     pip install --no-deps \
     keras-preprocessing==1.0.5

--- a/cibuild/dockerfiles/Dockerfile.devel-py3.6-cu116-ubuntu18.04
+++ b/cibuild/dockerfiles/Dockerfile.devel-py3.6-cu116-ubuntu18.04
@@ -5,12 +5,12 @@ RUN apt-get install -y libz-dev
 RUN apt-get install -y openjdk-8-jdk
 
 RUN pip install \
-    h5py==2.10.0 && \
-    spicy==0.16.0 && \
-    portpicker==1.4.0 && \
-    sklearn==0.0 && \
-    tensorflow-estimator==1.15.0 && \
-    grpcio==1.47.0 && \
-    grpcio-tools==1.47.0 && \
-    pyarrow==2.0.0 && \
+    h5py==2.10.0 \
+    spicy==0.16.0 \
+    portpicker==1.4.0 \
+    sklearn==0.0 \
+    tensorflow-estimator==1.15.0 \
+    grpcio==1.47.0 \
+    grpcio-tools==1.47.0 \
+    pyarrow==2.0.0 \
     fastparquet==0.6.0

--- a/cibuild/dockerfiles/Dockerfile.devel-py3.8-cu116-ubuntu20.04
+++ b/cibuild/dockerfiles/Dockerfile.devel-py3.8-cu116-ubuntu20.04
@@ -5,14 +5,14 @@ RUN apt-get install -y libz-dev
 RUN apt-get install -y openjdk-8-jdk
 
 RUN pip install \
-    h5py==2.10.0 && \
-    spicy==1.5.4 && \
-    scikit-learn==0.24.2 && \
-    portpicker==1.4.0 && \
-    sklearn==0.0 && \
-    tensorflow-estimator==1.15.2 && \
-    grpcio==1.47.0 && \
-    grpcio-tools==1.47.0 && \
-    pyarrow==2.0.0 && \
-    pandas==1.1.5 && \
+    h5py==2.10.0 \
+    spicy==1.5.4 \
+    scikit-learn==0.24.2 \
+    portpicker==1.4.0 \
+    sklearn==0.0 \
+    tensorflow-estimator==1.15.2 \
+    grpcio==1.47.0 \
+    grpcio-tools==1.47.0 \
+    pyarrow==2.0.0 \
+    pandas==1.1.5 \
     fastparquet==0.6.0.post1

--- a/cibuild/dockerfiles/Dockerfile.devel-py3.8-cu117-ubuntu22.04
+++ b/cibuild/dockerfiles/Dockerfile.devel-py3.8-cu117-ubuntu22.04
@@ -5,14 +5,14 @@ RUN apt-get install -y libz-dev
 RUN apt-get install -y openjdk-8-jdk
 
 RUN pip install \
-    h5py==2.10.0 && \
-    spicy==1.5.4 && \
-    scikit-learn==0.24.2 && \
-    portpicker==1.4.0 && \
-    sklearn==0.0 && \
-    tensorflow-estimator==1.15.2 && \
-    grpcio==1.47.0 && \
-    grpcio-tools==1.47.0 && \
-    pyarrow==2.0.0 && \
-    pandas==1.1.5 && \
+    h5py==2.10.0 \
+    spicy==1.5.4 \
+    scikit-learn==0.24.2 \
+    portpicker==1.4.0 \
+    sklearn==0.0 \
+    tensorflow-estimator==1.15.2 \
+    grpcio==1.47.0 \
+    grpcio-tools==1.47.0 \
+    pyarrow==2.0.0 \
+    pandas==1.1.5 \
     fastparquet==0.6.0.post1

--- a/cibuild/dockerfiles/Dockerfile.devel-py3.8-ubuntu20.04
+++ b/cibuild/dockerfiles/Dockerfile.devel-py3.8-ubuntu20.04
@@ -5,14 +5,14 @@ RUN apt-get install -y libz-dev
 RUN apt-get install -y openjdk-8-jdk
 
 RUN pip install \
-    h5py==2.10.0 && \
-    spicy==1.5.4 && \
-    scikit-learn==0.24.2 && \
-    portpicker==1.4.0 && \
-    sklearn==0.0 && \
-    tensorflow-estimator==1.15.2 && \
-    grpcio==1.47.0 && \
-    grpcio-tools==1.47.0 && \
-    pyarrow==2.0.0 && \
-    pandas==1.1.5 && \
+    h5py==2.10.0 \
+    spicy==1.5.4 \
+    scikit-learn==0.24.2 \
+    portpicker==1.4.0 \
+    sklearn==0.0 \
+    tensorflow-estimator==1.15.2 \
+    grpcio==1.47.0 \
+    grpcio-tools==1.47.0 \
+    pyarrow==2.0.0 \
+    pandas==1.1.5 \
     fastparquet==0.6.0.post1

--- a/cibuild/dockerfiles/Dockerfile.devel-py3.8-ubuntu22.04
+++ b/cibuild/dockerfiles/Dockerfile.devel-py3.8-ubuntu22.04
@@ -5,14 +5,14 @@ RUN apt-get install -y libz-dev
 RUN apt-get install -y openjdk-8-jdk
 
 RUN pip install \
-    h5py==2.10.0 && \
-    spicy==1.5.4 && \
-    scikit-learn==0.24.2 && \
-    portpicker==1.4.0 && \
-    sklearn==0.0 && \
-    tensorflow-estimator==1.15.2 && \
-    grpcio==1.47.0 && \
-    grpcio-tools==1.47.0 && \
-    pyarrow==2.0.0 && \
-    pandas==1.1.5 && \
+    h5py==2.10.0 \
+    spicy==1.5.4 \
+    scikit-learn==0.24.2 \
+    portpicker==1.4.0 \
+    sklearn==0.0 \
+    tensorflow-estimator==1.15.2 \
+    grpcio==1.47.0 \
+    grpcio-tools==1.47.0 \
+    pyarrow==2.0.0 \
+    pandas==1.1.5 \
     fastparquet==0.6.0.post1


### PR DESCRIPTION
There are some `&&` signs in the middle of package names in a single `pip install` command causing the single command interpreted as multiple commands by shell, and result in Dockerfile build failure.
This PR removes these `&&` signs.