### PR TITLE
Check dims for Q-R complementary strategy

### DIFF
--- a/tensorflow/python/ops/variable_scope.py
+++ b/tensorflow/python/ops/variable_scope.py
@@ -2343,6 +2343,10 @@ def get_multihash_variable(name,
   if complementary_strategy == 'Q-R':
     if num_of_partitions != 2:
       raise ValueError("the num_of_partitions must be 2 when using Q-R strategy.")
+    if dims[0][0] != dims[1][0]:
+      raise ValueError("The dims must have the same first dimension as \
+        embedding table capacity when using Q-R strategy. Otherwise the \
+        partition may not be complementary.")
     val_Q = get_variable_scope().get_variable(
             _get_default_variable_store(), name +'/multhash_Q',
             shape=dims[0], dtype=dtype,


### PR DESCRIPTION
According to https://arxiv.org/abs/1909.02107, Quotient-Remainder Complementary Partitions is one of complementary partitions. 

However, if the divisors are different, uniqueness of indexing vector for different ids may not be guaranteed, leading to potential collisions. For example, if divM=100 and modM=5, then the results for 7 and 12 are both <0,2>.